### PR TITLE
cbl mariner image fix

### DIFF
--- a/testsuite/conformance-test-plugins/azure-arc-agent-cleanup.yaml
+++ b/testsuite/conformance-test-plugins/azure-arc-agent-cleanup.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: azure-arc-agent-cleanup
   result-format: junit
 spec:
-  image: arck8sconformance.azurecr.io/arck8sconformance/agentcleanup:0.1.10
+  image: arck8sconformance.azurecr.io/arck8sconformance/agentcleanup:cbl-mariner-fix1
   imagePullPolicy: IfNotPresent
   name: plugin
   resources: {}

--- a/testsuite/conformance-test-plugins/azure-arc-agent-cleanup.yaml
+++ b/testsuite/conformance-test-plugins/azure-arc-agent-cleanup.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: azure-arc-agent-cleanup
   result-format: junit
 spec:
-  image: arck8sconformance.azurecr.io/arck8sconformance/agentcleanup:cbl-mariner-fix1
+  image: arck8sconformance.azurecr.io/arck8sconformance/agentcleanup:0.1.11
   imagePullPolicy: IfNotPresent
   name: plugin
   resources: {}

--- a/testsuite/conformance-test-plugins/azure-arc-ds-connect-platform.yaml
+++ b/testsuite/conformance-test-plugins/azure-arc-ds-connect-platform.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: azure-arc-ds-connect-platform
   result-format: junit
 spec:
-  image: arck8sconformance.azurecr.io/arck8sconformance/ds-connect-platform:0.1.26
+  image: arck8sconformance.azurecr.io/arck8sconformance/ds-connect-platform:cbl-mariner-fix1
   imagePullPolicy: IfNotPresent
   name: plugin
   resources: {}

--- a/testsuite/conformance-test-plugins/azure-arc-ds-connect-platform.yaml
+++ b/testsuite/conformance-test-plugins/azure-arc-ds-connect-platform.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: azure-arc-ds-connect-platform
   result-format: junit
 spec:
-  image: arck8sconformance.azurecr.io/arck8sconformance/ds-connect-platform:cbl-mariner-fix1
+  image: arck8sconformance.azurecr.io/arck8sconformance/ds-connect-platform:0.1.27
   imagePullPolicy: IfNotPresent
   name: plugin
   resources: {}

--- a/testsuite/conformance-test-plugins/azure-arc-platform.yaml
+++ b/testsuite/conformance-test-plugins/azure-arc-platform.yaml
@@ -11,7 +11,7 @@ sonobuoy-config:
   plugin-name: azure-arc-platform
   result-format: junit
 spec:
-  image: arck8sconformance.azurecr.io/arck8sconformance/platform:0.1.19
+  image: arck8sconformance.azurecr.io/arck8sconformance/platform:cbl-mariner-fix1
   imagePullPolicy: IfNotPresent
   name: plugin
   resources: {}

--- a/testsuite/conformance-test-plugins/azure-arc-platform.yaml
+++ b/testsuite/conformance-test-plugins/azure-arc-platform.yaml
@@ -11,7 +11,7 @@ sonobuoy-config:
   plugin-name: azure-arc-platform
   result-format: junit
 spec:
-  image: arck8sconformance.azurecr.io/arck8sconformance/platform:cbl-mariner-fix1
+  image: arck8sconformance.azurecr.io/arck8sconformance/platform:0.1.20
   imagePullPolicy: IfNotPresent
   name: plugin
   resources: {}

--- a/testsuite/launch.yaml
+++ b/testsuite/launch.yaml
@@ -36,7 +36,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: azure-arc-kubernetes-conformance
-        image: arck8sconformance.azurecr.io/arck8sconformance/launcher:cbl-mariner-fix1
+        image: arck8sconformance.azurecr.io/arck8sconformance/launcher:0.1.8
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: config-volume

--- a/testsuite/launch.yaml
+++ b/testsuite/launch.yaml
@@ -36,7 +36,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: azure-arc-kubernetes-conformance
-        image: arck8sconformance.azurecr.io/arck8sconformance/launcher:0.1.7
+        image: arck8sconformance.azurecr.io/arck8sconformance/launcher:cbl-mariner-fix1
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: config-volume


### PR DESCRIPTION
Platform plugin is failing on all distributions due to the base image mcr.microsoft.com/cbl-mariner/base/python:3.9 preventing the download of the latest Azure extensions.

I have replaced with new image "mcr.microsoft.com/azurelinux/base/python:3.12" and changed other places accordingly.